### PR TITLE
221 case study colours

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,3 @@ DEPENDENCIES
   neat (~> 1.7.2)
   rspec
   sass
-
-BUNDLED WITH
-   1.10.5

--- a/source/case-studies/template.html.haml
+++ b/source/case-studies/template.html.haml
@@ -12,8 +12,9 @@
         %blockquote= grad[:testimonial]
       .image.hide-desktop.no-padding
         = image_tag("graduates/#{grad[:image]}")
+%hr
 
-%section.backgrounded
+%section.no-padding-top
   .article--centered
     %article
       %dl

--- a/source/sass/_layout.scss
+++ b/source/sass/_layout.scss
@@ -3,12 +3,6 @@ section {
   text-align: center;
   padding: modular-scale(-1, $section-spacing) modular-scale(-5, $section-spacing);
   min-height: 400px;
-  &.no-min-height {
-    min-height: 0;
-  }
-  &.no-padding-bottom {
-    padding-bottom: 0;
-  }
   @include media($desktop) {
     padding: $section-spacing 0;
   }

--- a/source/sass/_mixins.scss
+++ b/source/sass/_mixins.scss
@@ -9,7 +9,7 @@
   @include row($display);
   margin-bottom: modular-scale(0);
   &:last-child {
-    margin-bottom: 0;
+    margin-bottom: -1px; // fix for last-child in Chrome, no ill effects in other browsers
   }
   *:last-child {
     margin-bottom: 0;

--- a/source/sass/_overrides.scss
+++ b/source/sass/_overrides.scss
@@ -1,0 +1,14 @@
+// Important stuff to override everything else
+
+.no-min-height {
+  min-height: 0 !important;
+}
+.no-padding {
+  padding: 0 !important;
+}
+.no-padding-bottom {
+  padding-bottom: 0 !important;
+}
+.no-padding-top {
+  padding-top: 0 !important;
+}

--- a/source/sass/all.scss
+++ b/source/sass/all.scss
@@ -2,3 +2,5 @@
 @import "vendor/bourbon/bourbon";
 @import "vendor/neat/neat";
 @import "base";
+
+@import "overrides";

--- a/source/team.html.haml
+++ b/source/team.html.haml
@@ -5,7 +5,7 @@
       %h1 Our Team
       %p We're a bunch of beautiful and diverse people here at Makers HQ. Come check us out.
 
-%section
+%section.no-padding-top
   .article--centered
     %article
       %h3 Who are we?


### PR DESCRIPTION
Closes #221 

Fixes case study colours, while abstracting a few overrides to a separate thing.

Also fixes the tiny gap between images and the bottom of stuff that appears on larger screens in Chrome for absolutely no reason whatsoever.