### PR TITLE
240 nav fixes

### DIFF
--- a/source/javascripts/navigation.js
+++ b/source/javascripts/navigation.js
@@ -10,11 +10,11 @@
   $(document).ready(function() {
     // only affect desktop navigation
     // hide after 5 seconds
-    var timeOut = window.setTimeout(hideNav, 5000);
+    var timeOut = window.setTimeout(hideNav, 5000000);
 
     $nav.hover(
     function() { clearTimeout(timeOut); },
-    function() { timeOut = window.setTimeout(hideNav, 5000); }
+    function() { timeOut = window.setTimeout(hideNav, 5000000); }
     );
 
     var lastScrollTop = 0;

--- a/source/javascripts/navigation.js
+++ b/source/javascripts/navigation.js
@@ -10,11 +10,11 @@
   $(document).ready(function() {
     // only affect desktop navigation
     // hide after 5 seconds
-    var timeOut = window.setTimeout(hideNav, 5000000);
+    var timeOut = window.setTimeout(hideNav, 5000);
 
     $nav.hover(
     function() { clearTimeout(timeOut); },
-    function() { timeOut = window.setTimeout(hideNav, 5000000); }
+    function() { timeOut = window.setTimeout(hideNav, 5000); }
     );
 
     var lastScrollTop = 0;

--- a/source/sass/_images.scss
+++ b/source/sass/_images.scss
@@ -19,7 +19,7 @@
 .image--brand {
   float: left;
   opacity: 0.9;
-  height: 56px;
+  height: 58px;
   padding: 8px modular-scale(1);
   img {
     height: 40px;

--- a/source/sass/_navigation.scss
+++ b/source/sass/_navigation.scss
@@ -82,7 +82,7 @@ header.navigation {
         li {
           display: inline;
           text-align: right;
-          padding-right: $base-spacing * 1.5;
+          padding-right: $base-spacing * $perfect-fourth;
           &.current a:after {
             content: "";
             position: absolute;

--- a/source/sass/_navigation.scss
+++ b/source/sass/_navigation.scss
@@ -106,8 +106,8 @@ header.navigation {
       }
     }
     &.hidden-nav {
-      transform: translateY(-76px);
-      -webkit-transform: translateY(-76px);
+      transform: translateY(-87px);
+      -webkit-transform: translateY(-87px);
     }
   }
 }

--- a/source/sass/_variables.scss
+++ b/source/sass/_variables.scss
@@ -59,12 +59,12 @@ $form-box-shadow-focus: none;
 $form-input-padding: modular-scale(-3);
 
 // Breakpoints
-$small-screen: em(480);
-$medium-screen: em(640);
-$large-screen: em(1024);
+$small-screen: 480px;
+$medium-screen: 640px;
+$large-screen: 1024px;
 
 $mobile: new-breakpoint(max-width $small-screen);
-$tablet: new-breakpoint(min-width $medium-screen);
+$tablet: new-breakpoint(min-width $medium-screen, max-width $large-screen);
 $desktop: new-breakpoint(min-width $large-screen);
 
 // Navigation


### PR DESCRIPTION
Closes #240 and some smaller issues too.


Smaller issues:

Breakpoints, which were expressed in `em`s and using Neat's `em()` function were breaking, because Neat was using 16px as the default base font-size instead of 18px (despite the fact it wasn't told to do this). **This had completely broken the tablet layout too**.

Easiest fix was to switch those breakpoints across to pixel values.