### PR TITLE
Sort mobile header sizes

### DIFF
--- a/source/sass/_mixins.scss
+++ b/source/sass/_mixins.scss
@@ -80,7 +80,7 @@
   margin-bottom: $base-line-height * $margin-lines;
 
   @include media($desktop) {
-    @include ma-font-size($step);
+    @include ma-font-size($step + 1);
   }
 }
 

--- a/source/sass/_typography.scss
+++ b/source/sass/_typography.scss
@@ -25,19 +25,19 @@ h6, {
 }
 
 h1 {
-  @include ma-header(4);
-}
-
-h2 {
   @include ma-header(3);
 }
 
-h3 {
+h2 {
   @include ma-header(2);
 }
 
+h3 {
+  @include ma-header(1);
+}
+
 h4 {
-  @include ma-header(0);
+  @include ma-header(-1);
   color: $medium-gray;
 
   &.leader, &.subheader {


### PR DESCRIPTION
Closes #252 

**PLEASE CHECK THIS DOES NOT BREAK MOBILE VERTICAL RHYTHM**

Make alterations to ma-header mixin so it scales differently for mobile, though this make break vertical rhythm on mobile devices. Alters base typographic sizes so mobile-first is considered. We may want to add an h5 group too.