### PR TITLE
Add ids for faq questions

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -45,7 +45,7 @@ activate :search_engine_sitemap
 # activate :automatic_image_sizes
 
 # Methods defined in the helpers block are available in templates
-helpers CurrentPageHelper, PartnerLogosHelper, MarkdownHelper, PossessiveHelper, SlugHelper, ImageHelper
+helpers CurrentPageHelper, PartnerLogosHelper, MarkdownHelper, PossessiveHelper, SlugHelper, ImageHelper, WebHelper
 
 # Proxy pages (https://middlemanapp.com/advanced/dynamic_pages/)
 data.graduates.each do | grad |

--- a/lib/web_helper.rb
+++ b/lib/web_helper.rb
@@ -1,0 +1,6 @@
+module WebHelper
+
+  def string_to_link(string)
+    string.gsub(/[^\s\w]/, '').downcase.gsub(' ', '-')
+  end
+end

--- a/source/partials/_faqs.html.haml
+++ b/source/partials/_faqs.html.haml
@@ -12,6 +12,6 @@
           .category
             %h3.subheader{id: "faq-category-#{index}"}= category[:category_name]
             - category[:faqs].each do |faq|
-              %dl.faq
+              %dl.faq{id: string_to_link(faq[:question])}
                 %dt= faq[:question]
                 %dd= markdown faq[:answer]

--- a/spec/web_helper_spec.rb
+++ b/spec/web_helper_spec.rb
@@ -1,0 +1,15 @@
+require "web_helper"
+
+class WebHelperWrapper
+  include WebHelper
+end
+
+describe WebHelperWrapper do
+
+  subject(:web_helper) { described_class.new }
+
+  it "converts strings to links" do
+    string = "What is the best thing about Makers?"
+    expect(web_helper.string_to_link(string)).to eq("what-is-the-best-thing-about-makers")
+  end
+end


### PR DESCRIPTION
We've added a helper that converts any string into a form usable for an id, and
added it to each faq question.

Closes #272