### PR TITLE
Adds ability to sort graduates by category

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -45,7 +45,7 @@ activate :search_engine_sitemap
 # activate :automatic_image_sizes
 
 # Methods defined in the helpers block are available in templates
-helpers CurrentPageHelper, PartnerLogosHelper, MarkdownHelper, PossessiveHelper, SlugHelper, ImageHelper
+helpers CurrentPageHelper, PartnerLogosHelper, MarkdownHelper, PossessiveHelper, SlugHelper, ImageHelper, GraduateHelper
 
 # Proxy pages (https://middlemanapp.com/advanced/dynamic_pages/)
 data.graduates.each do | grad |

--- a/lib/graduates_helper.rb
+++ b/lib/graduates_helper.rb
@@ -1,0 +1,21 @@
+module GraduatesHelper
+  def find_graduates(category = nil)
+    if category
+      find_graduates_by(category)
+    else
+      graduates
+    end
+  end
+
+  private
+
+  def find_graduates_by(category)
+    graduates.select do |graduate|
+      graduate["categories"] && graduate["categories"].include?(category)
+    end
+  end
+
+  def graduates
+    data.graduates
+  end
+end

--- a/source/landing.html.haml
+++ b/source/landing.html.haml
@@ -1,0 +1,1 @@
+= partial :"full_graduates", locals: { category: "career changer" }

--- a/source/partials/_full_graduates.html.haml
+++ b/source/partials/_full_graduates.html.haml
@@ -1,6 +1,6 @@
 %section.full-slider.no-padding
   .slider
-    - data.graduates.each do | grad |
+    - find_graduates(locals.fetch(:category, nil)).each do | grad |
       .slide
         .container
           .profile-row

--- a/source/partials/_preview_graduates.html.haml
+++ b/source/partials/_preview_graduates.html.haml
@@ -1,5 +1,5 @@
 .slider.lazy-slider
-  - data.graduates.each do |grad|
+  - find_graduates(locals.fetch(:category, nil)).each do |grad|
     .slider-content
       %figure.with-caption
         .image--centered

--- a/source/payment.html.haml
+++ b/source/payment.html.haml
@@ -3,7 +3,7 @@
   .container
     .centered-row
       %h1 Payment Options
-      %p We offer a variety of payment options. Price should never be a barrier to a student joining Makers Academy.
+      %p We offer a variety of payment options, and discounts for representatives of minority groups. Price should never be a barrier to a student joining Makers Academy.
 %section
   .container
     .centered-row

--- a/spec/graduate_helpers_spec.rb
+++ b/spec/graduate_helpers_spec.rb
@@ -1,0 +1,33 @@
+require "graduates_helper"
+
+class GraduateHelpersWrapper
+  include GraduatesHelper
+end
+
+describe GraduatesHelper do
+
+  subject(:graduate_helper) do
+    GraduateHelpersWrapper.new
+  end
+
+  before do
+    stub_graduate_data
+  end
+
+  let(:grad1) { { "name" => "Davina", "categories" => ["mum", "grad"] } }
+  let(:grad2) { { "name" => "Dave", "categories" => ["dad", "grad"] } }
+
+  it "finds all the graduates" do
+    expect(graduate_helper.find_graduates).to eq([grad1, grad2])
+  end
+
+  context "given a category to filter by" do
+    it "finds only gradutes for that category" do
+      expect(graduate_helper.find_graduates("dad")).to eq([grad2])
+    end
+  end
+
+  def stub_graduate_data
+    allow(graduate_helper).to receive(:graduates).and_return([grad1, grad2])
+  end
+end


### PR DESCRIPTION
This means that Arfah can build landing pages simply by doing

```
= partial :"full_graduates", locals: { category: "career changer" }
```

and it will only show graduates with that category

Closes #109