### PR TITLE
Remove duplicate content on curriculum page

### DIFF
--- a/source/partials/curriculum/_manifesto.html.haml
+++ b/source/partials/curriculum/_manifesto.html.haml
@@ -1,10 +1,8 @@
-%section.article.article--centered.no-padding-bottom
+%section.article.no-padding-bottom
   %article
     %h4.leader Our
     %h3 Manifesto
-    %p
-      %span Learning is so much more than a curriculum and some educational materials.
-      We currently use a mixture of workshops, exercises, projects, classroom break-out sessions and end-of-week challenges to help our students understand programming. The immersive environment, having expert coaches on hand all day, and pairing with other students are all key to our educational process. We have six main beliefs. Together, they form our manifesto.
+    %h4 We have six main beliefs. Together, they form our manifesto
 
 %section.no-padding-top
   .container


### PR DESCRIPTION
Change %span to %h4 and changed article-centered to article only. 
Visually QA'd with @jordanpoulton 
Closes #335 