### PR TITLE
View next case study story button

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -50,8 +50,7 @@ helpers CurrentPageHelper, PartnerLogosHelper, MarkdownHelper, PossessiveHelper,
 # Proxy pages (https://middlemanapp.com/advanced/dynamic_pages/)
 data.graduates.each do | grad |
   if grad[:case_study]
-    full_name = "#{grad[:first_name]} #{grad[:last_name]}"
-    url_slug = slug(full_name)
+    url_slug = graduate_slug(grad)
     proxy "/case-studies/#{url_slug}.html", "/case-studies/template.html", locals: { grad: grad }, ignore: true
   end
 end

--- a/lib/graduates_helper.rb
+++ b/lib/graduates_helper.rb
@@ -7,6 +7,11 @@ module GraduatesHelper
     end
   end
 
+  def next_graduate(current_graduate)
+    index = graduates.find_index { |graduate| graduate == current_graduate }
+    graduates[index.next % graduates.count]
+  end
+
   private
 
   def find_graduates_by(category)
@@ -18,4 +23,5 @@ module GraduatesHelper
   def graduates
     data.graduates
   end
+
 end

--- a/lib/slug_helper.rb
+++ b/lib/slug_helper.rb
@@ -3,4 +3,8 @@ module SlugHelper
   def slug(string)
     string.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
   end
+
+  def graduate_slug(graduate)
+    slug(graduate[:first_name] + ' ' + graduate[:last_name])
+  end
 end

--- a/source/case-studies/template.html.haml
+++ b/source/case-studies/template.html.haml
@@ -10,8 +10,9 @@
         %h1= "#{grad[:first_name]} #{grad[:last_name]}"
         %h4.subheader= grad[:summary]
         %blockquote= grad[:testimonial]
-      .image.hide-desktop.no-padding
-        = image_tag("graduates/#{grad[:image]}")
+        - next_grad = next_graduate(grad)
+        .image.hide-desktop.no-padding
+          = image_tag("graduates/#{grad[:image]}")
 %hr
 
 %section.no-padding-top
@@ -21,6 +22,8 @@
         - grad[:case_study].each do | qa |
           %dt= qa[:question]
           %dd= markdown qa[:answer]
+    .button-row
+      = link_to "Next Story", "/case-studies/#{graduate_slug(next_grad)}", class: "button--horizontal"
 
 = partial :"apply"
 

--- a/source/partials/_full_graduates.html.haml
+++ b/source/partials/_full_graduates.html.haml
@@ -14,7 +14,7 @@
               .button-row.shift-to-bottom
                 %p
                   - if grad[:case_study]
-                    = link_to "Read #{possessivize(grad[:first_name])} story", "/case-studies/#{slug(grad[:first_name] + ' ' + grad[:last_name])}", class: "button--horizontal"
+                    = link_to "Read #{possessivize(grad[:first_name])} story", "/case-studies/#{graduate_slug(grad)}", class: "button--horizontal"
                   - elsif grad[:case_study_link]
                     = link_to "Read #{possessivize(grad[:first_name])} story", grad[:case_study_link], class: "button--horizontal", target: "_blank"
                   - if grad[:blog_link]

--- a/spec/graduate_helpers_spec.rb
+++ b/spec/graduate_helpers_spec.rb
@@ -27,6 +27,18 @@ describe GraduatesHelper do
     end
   end
 
+  describe 'finds the next graduate' do
+    it 'when passed the first in the set' do
+      expect(graduate_helper.next_graduate(grad1)).to eq grad2
+    end
+
+    context 'when given the last graduate' do
+      it 'finds the first graduate' do
+        expect(graduate_helper.next_graduate(grad2)).to eq grad1
+      end
+    end
+  end
+
   def stub_graduate_data
     allow(graduate_helper).to receive(:graduates).and_return([grad1, grad2])
   end

--- a/spec/slug_helper_spec.rb
+++ b/spec/slug_helper_spec.rb
@@ -9,7 +9,16 @@ describe SlugHelperWrapper do
   let(:string) { "Alice 'Jimmy' Jameson" }
   let(:slug) { "alice-jimmy-jameson" }
 
+  let(:graduate) do
+    { first_name: "Alice 'Jimmy'", last_name: "Jameson" }
+  end
+  let(:graduate_slug) { "alice-jimmy-jameson" }
+
   it "converts strings to slugs" do
     expect(subject.slug(string)).to eq(slug)
+  end
+
+  it "converts graduates to slugs" do
+    expect(subject.graduate_slug(graduate)).to eq(graduate_slug)
   end
 end


### PR DESCRIPTION
Closes #287

The 'Read Next Story' button appears below the graduate quote on desktop. On
mobile, it appears at the bottom of the story. This seemed to look cleaner to us.
The 'Next Story' button loops, such that clicking it on the last grad will
bring you back to the first grad.