### PR TITLE
Adds deprecated browser warning for <= IE8

### DIFF
--- a/:w
+++ b/:w
@@ -1,0 +1,8 @@
+h3.deprecated-browser-warning {
+  background-color: red;
+  z-index: 1000;
+  text-align: center;
+  position: fixed;
+  color: white;
+  width: 100%;
+}

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -1,7 +1,12 @@
 !!!
 %html
   %head
+    <!--[if gt IE 8]><!-->
     = stylesheet_link_tag "all"
+    <![endif]-->
+    <!--[if lte IE 8]><!-->
+    = stylesheet_link_tag "compatibility"
+    <![endif]-->
     = partial :"analytics_scripts"
     %script{src: "//use.typekit.net/fla8fba.js"}
     :javascript
@@ -20,8 +25,8 @@
   %body{class: page_classes}
     - # Tag manager must go in the body, the other analytics scripts go in the head
     = partial :"google_tag_manager"
+    = partial :"deprecated_browser_warning"
     = partial :"navigation"
-
     = partial :"facebook_sdk"
     
     = yield

--- a/source/partials/_deprecated_browser_warning.html.haml
+++ b/source/partials/_deprecated_browser_warning.html.haml
@@ -1,0 +1,4 @@
+<p class='deprecated-browser-warning'>
+Hey! It looks like you're using an old browser - here at Makers Academy we are always looking to use the most cutting-edge features the web offers
+and unfortunately your browser doesn't allow us to do this. We know you can't always switch, but we strongly recommend using the latest versions of <a href='https://www.mozilla.org/en-GB/firefox/new/'>Mozilla Firefox</a> or <a href='http://www.google.com/chrome/'>Google Chrome</a>.
+</p>

--- a/source/sass/_base.scss
+++ b/source/sass/_base.scss
@@ -16,6 +16,7 @@
 @import "figures";
 @import "images";
 @import "videos";
+@import "deprecated_browser_warning";
 
 // Layouts
 @import "navigation";

--- a/source/sass/_deprecated_browser_warning.scss
+++ b/source/sass/_deprecated_browser_warning.scss
@@ -1,0 +1,15 @@
+p.deprecated-browser-warning {
+  background-color: #AA1925;
+  z-index: 1000;
+  position: fixed;
+  color: white;
+  height: 160px;
+  width: 100%;
+  margin-top: -10px;
+  padding: 120px 0 0 10px;
+  font-size: 24px;
+}
+
+p.deprecated-browser-warning a{
+  color: #003340;
+}

--- a/source/sass/_layout.scss
+++ b/source/sass/_layout.scss
@@ -26,7 +26,6 @@ section {
   }
 }
 
-
 hr {
   border-bottom: $base-border;
   border-left: none;
@@ -100,4 +99,8 @@ hr {
 
 .vertical-center {
   vertical-align: middle !important;
+}
+
+p.deprecated-browser-warning {
+  display: none;
 }

--- a/source/sass/compatibility.scss
+++ b/source/sass/compatibility.scss
@@ -1,0 +1,1 @@
+@import 'deprecated_browser_warning'


### PR DESCRIPTION
This is subsequent to the previous PR #292, which was rolled back because the deprecated browser warning was appearing for chrome users. This issue should now be fixed.

http://staging.makersacademy.com/